### PR TITLE
fix!: add `Send` and `Sync` to `Intervention`

### DIFF
--- a/src/intervention.rs
+++ b/src/intervention.rs
@@ -9,6 +9,9 @@ pub struct Intervention<B: RawBindings = Bindings> {
     _bindings: PhantomData<B>,
 }
 
+unsafe impl Send for Intervention {}
+unsafe impl Sync for Intervention {}
+
 impl<B: RawBindings> Debug for Intervention<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Intervention")


### PR DESCRIPTION
Add the `Send` and `Sync` traits to `Intervention`, this is the last data structure of this crate that is missing them.

The lack of these traits makes things more complicated with using this crate inside of async code.

Based on my tests everything seems to be working fine with these traits added.
